### PR TITLE
Fix/input: Input 컴포넌트 스타일 기본설정 수정

### DIFF
--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -15,6 +15,8 @@ export type InputProps<T extends FieldValues> = {
   size: string;
   /** input 스타일 지정, 미지정시 기본 bg-white pl-[20px] py-[15px] border-[1px] border-gray-20 focus:border-[1px] focus:border-purple-50 focus:outline-none disabled:bg-gray-10 적용 */
   inputStyle?: string;
+  /** 텍스트 스타일 지정, 미지정시 기본 text-body-reading text-gray-90 placeholder:text-gray-50 적용 */
+  textStyle?: string;
   /** 플레이스홀더 */
   placeholder?: string;
   /** 최대 글자 수, 제한 없는 경우 생략 */
@@ -34,7 +36,8 @@ export default function Input<T extends FieldValues>({
   size,
   maxLength,
   placeholder,
-  inputStyle = 'bg-white pl-[20px] py-[15px] border-[1px] border-gray-20 focus:border-[1px] focus:border-purple-50 focus:outline-none disabled:bg-gray-10',
+  inputStyle = 'bg-white pl-[20px] py-[15px] rounded-[10px] border-[1px] border-gray-20 focus:border-[1px] focus:border-purple-50 focus:outline-none disabled:bg-gray-10',
+  textStyle = 'text-body-reading text-gray-90 placeholder:text-gray-50',
   showCharacterCount = false,
   showPasswordToggle = false,
   children,
@@ -66,7 +69,7 @@ export default function Input<T extends FieldValues>({
             type={inputType}
             maxLength={maxLength}
             placeholder={placeholder}
-            className={`absolute w-full h-full ${showCharacterCount && showPasswordToggle && 'pr-[115px]'} ${showCharacterCount && !showPasswordToggle && 'pr-[82px]'} ${!showCharacterCount && showPasswordToggle && 'pr-[56px]'} ${!showCharacterCount && !showPasswordToggle && 'pr-[20px]'} ${inputStyle} rounded-[10px] text-body-reading text-gray-90 placeholder:text-gray-50`}
+            className={`absolute w-full h-full ${showCharacterCount && showPasswordToggle && 'pr-[115px]'} ${showCharacterCount && !showPasswordToggle && 'pr-[82px]'} ${!showCharacterCount && showPasswordToggle && 'pr-[56px]'} ${!showCharacterCount && !showPasswordToggle && 'pr-[20px]'} ${inputStyle} ${textStyle}`}
             onChange={handleInputChange(field, maxLength)}
           />
           <div

--- a/src/components/ui/SearchInput.tsx
+++ b/src/components/ui/SearchInput.tsx
@@ -29,7 +29,7 @@ export default function SearchInput<T extends FieldValues>({
       control={control}
       size={size}
       placeholder={placeholder}
-      inputStyle={`bg-transparent border border-gray-30 ${iconPosition === 'left' ? 'pl-[49px] pr-[15px]' : 'pr-[49px] pl-[15px]'} py-[9px]`}
+      inputStyle={`bg-transparent rounded-[10px] border border-gray-30 ${iconPosition === 'left' ? 'pl-[49px] pr-[15px]' : 'pr-[49px] pl-[15px]'} py-[9px]`}
       type='text'
     >
       <img


### PR DESCRIPTION
## ✅ 작업 사항

- input 태그에 적용되는 스타일을 컨테이너 영역 (inputStyle => border, bg, padding 등..), 텍스트 영역(textStyle => 텍스트 크기, 색상, 플레이스홀더 스타일 등..)으로 나눔
- inputStyle과 textStyle을 지정하지 않는 경우 디자인시스템의 가장 기본 디자인 적용
- SearchInput, 제목 입력 필드 등 다른 스타일 설정이 필요한 경우 props로 지정

- input에 적용되는 스타일을 두가지 유형으로 나눈 이유
  - bgColor, padding, font, .. 를 모두 쪼개는 것 => 어떤 props가 있는지 일일이 파악하기 번거로움
  - 눈으로 봤을 때 영역니 뚜렷하게 나눠지고 현재 디자인에서 크게 달라지는 지점이 보더 색상, 패딩값, 포커스 효과가 있는지 / 텍스트 스타일로 나눠진다고 생각하는데 만약 모든 스타일을 묶어서 받는다면 한가지 타입만 수정하면 되는데 모든 스타일을 지정해줘야하고 현재 Input을 사용하는 컴포넌트들도 수정 필요

=> 이렇게 생각해서 두가지 스타일 타입으로 나눴는데 주관적일 수 있다고 생각합니다! 혹시 세분화 or 하나로 통일하는게 좋다고 생각이 들면 알려주세요!

<br/>

## 📸 스크린샷
- 기존에 Input 관련 컴포넌트들 문제 없이 스타일 적용되고 있습니다
<img width="458" alt="image" src="https://github.com/user-attachments/assets/4d4bd0f1-6c1b-447a-a3af-99c3a33ac67c" />
<img width="440" alt="image" src="https://github.com/user-attachments/assets/60b1a23b-da2e-4b2c-86a5-4ca98d3a2b62" />
