### PR TITLE
Fix/dropdown: 드롭다운 높이제한, 호버/액티브 스타일 추가

### DIFF
--- a/src/components/ui/dropdown/Dropdown.stories.tsx
+++ b/src/components/ui/dropdown/Dropdown.stories.tsx
@@ -75,6 +75,26 @@ export const Disabled: Story = {
   },
 };
 
+/** 메뉴 아이템이 최대 높이를 넘어서는 경우 */
+export const Overflow: Story = {
+  render: DropdownTemplate,
+  args: {
+    type: 'default',
+    menuList: [
+      { id: 'd1', label: '메뉴 1' },
+      { id: 'd2', label: '메뉴 2' },
+      { id: 'd3', label: '메뉴 3' },
+      { id: 'd4', label: '메뉴 4' },
+      { id: 'd5', label: '메뉴 5' },
+      { id: 'd6', label: '메뉴 6' },
+      { id: 'd7', label: '메뉴 7' },
+      { id: 'd8', label: '메뉴 8' },
+      { id: 'd9', label: '메뉴 9' },
+    ],
+    selectedItem: '메뉴 1',
+  },
+};
+
 /** 커스텀 스타일 드롭다운 */
 export const CustomStyle: Story = {
   render: DropdownTemplate,
@@ -172,6 +192,60 @@ export const DisabledInteractionTest: Story = {
     await step('반복 클릭 후 상태 확인', async () => {
       const openCount = canvas.getByTestId('dropdown-open-count');
       expect(openCount).toHaveTextContent('드롭다운 열림 시도 횟수: 0');
+    });
+  },
+};
+
+/** menuContainerMaxHeight 속성 테스트 */
+export const CustomMaxHeight: Story = {
+  render: DropdownTemplate,
+  args: {
+    type: 'default',
+    menuList: [
+      { id: 'd1', label: '메뉴 1' },
+      { id: 'd2', label: '메뉴 2' },
+      { id: 'd3', label: '메뉴 3' },
+      { id: 'd4', label: '메뉴 4' },
+      { id: 'd5', label: '메뉴 5' },
+      { id: 'd6', label: '메뉴 6' },
+      { id: 'd7', label: '메뉴 7' },
+      { id: 'd8', label: '메뉴 8' },
+      { id: 'd9', label: '메뉴 9' },
+    ],
+    selectedItem: '메뉴 1',
+    menuContainerMaxHeight: 100,
+    menuContainerTestId: 'custom-max-height-container',
+    triggerTestId: 'dropdown-trigger',
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('드롭다운 열기', async () => {
+      const trigger = canvas.getByTestId('dropdown-trigger');
+      await userEvent.click(trigger);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    await step('메뉴 컨테이너의 최대 높이 확인', async () => {
+      const menuContainer = canvas.getByTestId('custom-max-height-container');
+
+      const computedStyle = window.getComputedStyle(menuContainer);
+      expect(computedStyle.maxHeight).toBe('100px');
+
+      expect(menuContainer.style.maxHeight).toBe('100px');
+
+      expect(menuContainer).toBeInTheDocument();
+      expect(canvas.getByText('메뉴 9')).toBeInTheDocument();
+    });
+
+    await step('드롭다운 닫기', async () => {
+      const trigger = canvas.getByTestId('dropdown-trigger');
+      await userEvent.click(trigger);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(canvas.queryByTestId('custom-max-height-container')).not.toBeInTheDocument();
     });
   },
 };

--- a/src/components/ui/dropdown/Dropdown.tsx
+++ b/src/components/ui/dropdown/Dropdown.tsx
@@ -25,12 +25,18 @@ type DropdownProps = {
   selectedTextStyle?: string;
   /** 드롭다운 메뉴 아이템 텍스트에 적용될 스타일 */
   menuItemTextStyle?: string;
+  /** 드롭다운 메뉴 컨테이너의 최대 높이 */
+  menuContainerMaxHeight?: number;
   /** 드롭다운이 열릴 때 실행될 콜백 함수 */
   onOpen?: () => void;
   /** 드롭다운이 닫힐 때 실행될 콜백 함수 */
   onClose?: () => void;
   /** 드롭다운 비활성화 여부 */
   disabled?: boolean;
+  /** 드롭다운 트리거(항상 보이는 부분) 테스트 ID */
+  triggerTestId?: string;
+  /** 드롭다운 메뉴 컨테이너 테스트 ID (펼쳐진 영역) */
+  menuContainerTestId?: string;
 };
 
 const DROPDOWN_SIZE = {
@@ -61,6 +67,8 @@ const DROPDOWN_TEXT_STYLE = {
 const DROPDOWN_MENU_ITEM_STYLE = 'px-[10px] py-[5px] hover:bg-gray-10 active:bg-gray-30';
 const DROPDOWN_MENU_ITEM_TEXT_STYLE = 'text-headline2 font-normal';
 
+const DROPDOWN_MENU_MAX_HEIGHT = 200;
+
 export default function Dropdown({
   type = 'default',
   menuList,
@@ -70,9 +78,12 @@ export default function Dropdown({
   menuItemStyle,
   selectedTextStyle,
   menuItemTextStyle,
+  menuContainerMaxHeight,
   disabled,
   onOpen,
   onClose,
+  triggerTestId,
+  menuContainerTestId,
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -122,6 +133,7 @@ export default function Dropdown({
       } ${selectedTextStyle || DROPDOWN_TEXT_STYLE[type]} text-nowrap ${disabled ? 'cursor-not-allowed text-label-assistive' : 'cursor-pointer'} select-none`}
       ref={dropdownRef}
       onClick={handleToggle}
+      data-testid={triggerTestId}
     >
       {selectedItem}
       <img
@@ -130,7 +142,11 @@ export default function Dropdown({
         className='absolute right-[14px] w-[14px] h-[14px]'
       />
       {isOpen && (
-        <div className='absolute top-full left-1/2 -translate-x-1/2 translate-y-[10.5px] flex flex-col justify-start items-start gap-[5px] px-[4px] py-[6px] bg-white rounded-[5px] shadow shadow-[0px_0px_7px_0px_rgba(70, 72, 84, 0.10)]'>
+        <div
+          className={`absolute top-full left-1/2 -translate-x-1/2 translate-y-[10.5px] flex flex-col justify-start items-start gap-[5px] px-[4px] py-[6px] bg-white rounded-[5px] shadow shadow-[0px_0px_7px_0px_rgba(70, 72, 84, 0.10)] overflow-y-auto`}
+          style={{ maxHeight: menuContainerMaxHeight || DROPDOWN_MENU_MAX_HEIGHT }}
+          data-testid={menuContainerTestId}
+        >
           {menuList.map((menu) => (
             <div
               key={menu.id}

--- a/src/components/ui/dropdown/Dropdown.tsx
+++ b/src/components/ui/dropdown/Dropdown.tsx
@@ -58,7 +58,7 @@ const DROPDOWN_TEXT_STYLE = {
   withInput: 'text-gray-90 text-body-reading',
 } as const;
 
-const DROPDOWN_MENU_ITEM_STYLE = 'px-[10px] py-[5px]';
+const DROPDOWN_MENU_ITEM_STYLE = 'px-[10px] py-[5px] hover:bg-gray-10 active:bg-gray-30';
 const DROPDOWN_MENU_ITEM_TEXT_STYLE = 'text-headline2 font-normal';
 
 export default function Dropdown({


### PR DESCRIPTION
## ✅ 작업 사항

- 드롭다운 높이 제한 (기본 최대높이 200 설정, 필요할시 props로 전달 가능)
- 드롭다운 메뉴 아이템 호버/액티브 상태 스타일 추가

<br/>

## 📸 스크린샷
![드롭다운 높이제한, 호버, 액티브](https://github.com/user-attachments/assets/ee646cf8-a831-4fc6-aa06-5b0ca2369b12)


<br/>
