### PR TITLE
Feat/radio:라디오 버튼 공용 컴포넌트

### DIFF
--- a/src/components/ui/radio/Radio.stories.tsx
+++ b/src/components/ui/radio/Radio.stories.tsx
@@ -1,0 +1,154 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useForm, FormProvider } from 'react-hook-form';
+import Radio from './Radio';
+
+const meta: Meta<typeof Radio> = {
+  title: 'UI/Radio',
+  component: Radio,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => {
+      const methods = useForm({
+        defaultValues: {
+          radioGroup: '',
+        },
+      });
+      return (
+        <FormProvider {...methods}>
+          <form onSubmit={(e) => e.preventDefault()}>
+            <Story />
+          </form>
+        </FormProvider>
+      );
+    },
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Radio>;
+
+export const Default: Story = {
+  args: {
+    htmlFor: 'default-radio',
+    name: 'radioGroup',
+    value: 'default',
+  },
+  render: (args) => {
+    const { register } = useForm();
+    return (
+      <Radio
+        {...args}
+        register={register}
+      />
+    );
+  },
+};
+
+export const Checked: Story = {
+  args: {
+    htmlFor: 'checked-radio',
+    value: 'checked',
+  },
+  render: (args) => {
+    const { register } = useForm({
+      defaultValues: {
+        radioGroup: 'checked',
+      },
+    });
+    return (
+      <Radio
+        {...args}
+        name='radioGroup'
+        register={register}
+      />
+    );
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    htmlFor: 'disabled-radio',
+    name: 'radioGroup',
+    value: 'disabled',
+    disabled: true,
+  },
+  render: (args) => {
+    const { register } = useForm();
+    return (
+      <Radio
+        {...args}
+        register={register}
+      />
+    );
+  },
+};
+
+export const WithLabel: Story = {
+  args: {
+    htmlFor: 'label-radio',
+    name: 'radioGroup',
+    value: 'withLabel',
+  },
+  render: (args) => {
+    const { register } = useForm();
+    return (
+      <Radio
+        {...args}
+        register={register}
+      >
+        <span className='ml-2 text-sm'>라디오 옵션</span>
+      </Radio>
+    );
+  },
+};
+
+export const RadioGroup: Story = {
+  render: () => {
+    const { register } = useForm({
+      defaultValues: {
+        favoriteColor: 'blue',
+      },
+    });
+
+    return (
+      <div className='flex flex-col gap-2'>
+        <Radio
+          htmlFor='red'
+          name='favoriteColor'
+          value='red'
+          register={register}
+        >
+          <span className='ml-2 text-sm'>빨간색</span>
+        </Radio>
+        <Radio
+          htmlFor='blue'
+          name='favoriteColor'
+          value='blue'
+          register={register}
+        >
+          <span className='ml-2 text-sm'>파란색</span>
+        </Radio>
+        <Radio
+          htmlFor='green'
+          name='favoriteColor'
+          value='green'
+          register={register}
+        >
+          <span className='ml-2 text-sm'>초록색</span>
+        </Radio>
+        <Radio
+          htmlFor='disabled'
+          name='favoriteColor'
+          value='disabled'
+          disabled
+          register={register}
+        >
+          <span className='ml-2 text-sm'>선택 불가능</span>
+        </Radio>
+      </div>
+    );
+  },
+};

--- a/src/components/ui/radio/Radio.stories.tsx
+++ b/src/components/ui/radio/Radio.stories.tsx
@@ -3,7 +3,7 @@ import { useForm, FormProvider } from 'react-hook-form';
 import Radio from './Radio';
 
 const meta: Meta<typeof Radio> = {
-  title: 'UI/Radio',
+  title: 'Components/Radio',
   component: Radio,
   parameters: {
     layout: 'centered',

--- a/src/components/ui/radio/Radio.tsx
+++ b/src/components/ui/radio/Radio.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { FieldValues, Path, UseFormRegister } from 'react-hook-form';
+
+type RadioProps<T extends FieldValues> = {
+  /** 라디오 버튼과 함께 표시될 컴포넌트 */
+  children?: React.ReactNode;
+  /** value를 제어하기 위한 register 함수 (useForm 혹은 useFormContext 반환값) */
+  register: UseFormRegister<T>;
+  /** 라디오 버튼의 이름, 라디오 버튼 그룹을 구분하는 식별자 */
+  name: Path<T>;
+  /** 라디오버튼의 고유 id */
+  htmlFor: string;
+  /** 라디오 버튼의 값 */
+  value: string;
+  /** 라디오 버튼 선택 여부 */
+  checked: boolean;
+  /** 라디오 버튼 변경 시 호출할 콜백함수 */
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  /** 라디오 버튼 비활성화 여부 */
+  disabled?: boolean;
+};
+export default function Radio<T extends FieldValues>({
+  children,
+  register,
+  name,
+  htmlFor,
+  value,
+  checked,
+  onChange,
+  disabled,
+}: RadioProps<T>) {
+  return (
+    <label
+      htmlFor={htmlFor}
+      className='flex items-center gap-2'
+    >
+      <input
+        type='radio'
+        id={htmlFor}
+        {...register(name)}
+        value={value}
+        checked={checked}
+        onChange={onChange}
+        disabled={disabled}
+      />
+      {children}
+    </label>
+  );
+}

--- a/src/components/ui/radio/Radio.tsx
+++ b/src/components/ui/radio/Radio.tsx
@@ -13,12 +13,12 @@ type RadioProps<T extends FieldValues> = {
   htmlFor: string;
   /** 라디오 버튼의 값 */
   value: string;
-  /** 라디오 버튼 선택 여부 */
-  checked: boolean;
-  /** 라디오 버튼 변경 시 호출할 콜백함수 */
+  /** 라디오 버튼 변경 시 추가적인 동작을 호출하고 싶은 경우 사용 */
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   /** 라디오 버튼 비활성화 여부 */
   disabled?: boolean;
+  /** 컨테이너에 적용될 스타일 */
+  containerStyle?: string;
 };
 export default function Radio<T extends FieldValues>({
   children,
@@ -26,22 +26,24 @@ export default function Radio<T extends FieldValues>({
   name,
   htmlFor,
   value,
-  checked,
   onChange,
   disabled,
+  containerStyle,
 }: RadioProps<T>) {
   return (
     <label
       htmlFor={htmlFor}
-      className='flex items-center gap-2'
+      className={`${containerStyle || 'flex items-center'}`}
     >
       <input
         type='radio'
         id={htmlFor}
         {...register(name)}
+        name={name}
         value={value}
-        checked={checked}
-        onChange={onChange}
+        onChange={(e) => {
+          onChange?.(e);
+        }}
         disabled={disabled}
       />
       {children}

--- a/src/components/ui/radio/Radio.tsx
+++ b/src/components/ui/radio/Radio.tsx
@@ -7,7 +7,7 @@ type RadioProps<T extends FieldValues> = {
   children?: React.ReactNode;
   /** value를 제어하기 위한 register 함수 (useForm 혹은 useFormContext 반환값) */
   register: UseFormRegister<T>;
-  /** 라디오 버튼의 이름, 라디오 버튼 그룹을 구분하는 식별자 */
+  /** 폼에서 사용할 name, 라디오 버튼 그룹을 구분하는 식별자 */
   name: Path<T>;
   /** 라디오버튼의 고유 id */
   htmlFor: string;
@@ -45,7 +45,7 @@ export default function Radio<T extends FieldValues>({
           onChange?.(e);
         }}
         disabled={disabled}
-        className='appearance-none w-[20px] h-[20px] rounded-full bg-white border-box border-[1.6px] border-gray-30 checked:border-[6px] checked:border-purple-50 cursor-pointer'
+        className='appearance-none w-[20px] h-[20px] rounded-full bg-white border-box border-[1.6px] border-gray-30 checked:border-[6px] checked:border-purple-50 cursor-pointer disabled:cursor-not-allowed disabled:bg-gray-30'
       />
       {children}
     </label>

--- a/src/components/ui/radio/Radio.tsx
+++ b/src/components/ui/radio/Radio.tsx
@@ -45,6 +45,7 @@ export default function Radio<T extends FieldValues>({
           onChange?.(e);
         }}
         disabled={disabled}
+        className='appearance-none w-[20px] h-[20px] rounded-full bg-white border-box border-[1.6px] border-gray-30 checked:border-[6px] checked:border-purple-50 cursor-pointer'
       />
       {children}
     </label>


### PR DESCRIPTION
## ✅ 작업 사항

- 라디오 버튼 구현
  - 커스텀 디자인 적용
  - react-hook-form으로 제어할 수 있도록 구현
  - children 추가해서 같이 클릭될 label 전달할 수 있도록 구현
- 스토리북 스토리 추가 (기본, checked 상태, disabled 상태, children 넘겨준 상태, 라디오 그룹)

<br/>

## 📸 스크린샷
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/c8d3d562-127b-45be-9896-7c786a134992" />
<img width="148" alt="image" src="https://github.com/user-attachments/assets/e82d7470-e830-41ad-85cf-3e98cf4cb78f" />


<br/>

## 🧑‍💻 기타

- disabled 는 피그마에 없긴한데 임시로 배경색, 커서 not-allowed만 추가했습니다
- 퀴즈 생성폼 pr이 너무 거대해지고 있는 거 같아서.. ㅠㅠ 일부만 먼저 올립니다!!
