### PR TITLE
Feat/x icon: svg 대신 사용할 x 아이콘 컴포넌트

### DIFF
--- a/src/components/icon/XIcon.stories.tsx
+++ b/src/components/icon/XIcon.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import XIcon from './XIcon';
+
+const meta = {
+  title: 'Icon/XIcon',
+  component: XIcon,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof XIcon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    size: 14,
+    thickness: 2,
+    color: 'black',
+    useTailwind: false,
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 30,
+    thickness: 3,
+    color: '#696A7D',
+    useTailwind: false,
+  },
+};
+
+export const WithHex: Story = {
+  args: {
+    size: 24,
+    thickness: 2,
+    color: '#FF0000',
+    useTailwind: false,
+  },
+};
+
+export const WithTailwind: Story = {
+  args: {
+    size: 24,
+    thickness: 2,
+    color: 'bg-purple-50',
+    useTailwind: true,
+  },
+};

--- a/src/components/icon/XIcon.tsx
+++ b/src/components/icon/XIcon.tsx
@@ -4,16 +4,16 @@ interface XIconProps {
   /** 선 두께 (픽셀 단위) */
   thickness?: number;
   /**
-   * 선 색상 - CSS 색상값(hex, rgb 등) 또는 Tailwind 클래스명
+   * 선 색상 - CSS 색상값(hex, rgb 등) 또는 Tailwind 클래스명, 기본값 'black'
+   * tailwind 클래스명 사용시 useTailwind 속성을 true로 설정
    * 예: "#FF0000" 또는 "bg-gray-30"
    */
   color?: string;
-  /** Tailwind 클래스 사용 여부 */
+  /** Tailwind 클래스 사용 여부, 기본값 false */
   useTailwind?: boolean;
 }
 
 export default function XIcon({ size = 14, thickness = 1, color = 'black', useTailwind = false }: XIconProps) {
-  // 첫 번째 선 스타일
   const line1Style = useTailwind
     ? {
         position: 'absolute' as const,
@@ -37,7 +37,6 @@ export default function XIcon({ size = 14, thickness = 1, color = 'black', useTa
         borderRadius: thickness / 2,
       };
 
-  // 두 번째 선 스타일
   const line2Style = useTailwind
     ? {
         position: 'absolute' as const,

--- a/src/components/icon/XIcon.tsx
+++ b/src/components/icon/XIcon.tsx
@@ -12,7 +12,7 @@ interface XIconProps {
   useTailwind?: boolean;
 }
 
-export default function XIcon({ size = 14, thickness = 2, color = 'black', useTailwind = false }: XIconProps) {
+export default function XIcon({ size = 14, thickness = 1, color = 'black', useTailwind = false }: XIconProps) {
   // 첫 번째 선 스타일
   const line1Style = useTailwind
     ? {

--- a/src/components/icon/XIcon.tsx
+++ b/src/components/icon/XIcon.tsx
@@ -1,0 +1,76 @@
+interface XIconProps {
+  /** 아이콘 크기 (픽셀 단위) */
+  size?: number;
+  /** 선 두께 (픽셀 단위) */
+  thickness?: number;
+  /**
+   * 선 색상 - CSS 색상값(hex, rgb 등) 또는 Tailwind 클래스명
+   * 예: "#FF0000" 또는 "bg-gray-30"
+   */
+  color?: string;
+  /** Tailwind 클래스 사용 여부 */
+  useTailwind?: boolean;
+}
+
+export default function XIcon({ size = 14, thickness = 2, color = 'black', useTailwind = false }: XIconProps) {
+  // 첫 번째 선 스타일
+  const line1Style = useTailwind
+    ? {
+        position: 'absolute' as const,
+        width: size,
+        height: thickness,
+        top: '50%',
+        left: 0,
+        transform: 'translateY(-50%) rotate(45deg)',
+        transformOrigin: 'center',
+        borderRadius: thickness / 2,
+      }
+    : {
+        position: 'absolute' as const,
+        width: size,
+        height: thickness,
+        backgroundColor: color,
+        top: '50%',
+        left: 0,
+        transform: 'translateY(-50%) rotate(45deg)',
+        transformOrigin: 'center',
+        borderRadius: thickness / 2,
+      };
+
+  // 두 번째 선 스타일
+  const line2Style = useTailwind
+    ? {
+        position: 'absolute' as const,
+        width: size,
+        height: thickness,
+        top: '50%',
+        left: 0,
+        transform: 'translateY(-50%) rotate(-45deg)',
+        transformOrigin: 'center',
+        borderRadius: thickness / 2,
+      }
+    : {
+        position: 'absolute' as const,
+        width: size,
+        height: thickness,
+        backgroundColor: color,
+        top: '50%',
+        left: 0,
+        transform: 'translateY(-50%) rotate(-45deg)',
+        transformOrigin: 'center',
+        borderRadius: thickness / 2,
+      };
+
+  return (
+    <div style={{ position: 'relative', width: size, height: size }}>
+      <div
+        className={useTailwind ? color : ''}
+        style={line1Style}
+      />
+      <div
+        className={useTailwind ? color : ''}
+        style={line2Style}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## ✅ 작업 사항

- x 아이콘 컬러 크기가 여러 종류인데 모두 이미지로 저장하기에는 구분이 헷갈릴 것 같고 svg를 꼭 사용해야하는 케이스는 아닌 것 같아서 컬러, 두께, 크기 props로 넘겨 사용할 수 있는 컴포넌트를 만들었습니다!
- svg 코드를 봤을 때 두께 언급이 없으면 1px이라고해서 기본두께 1로 지정해뒀습니다
- 아이콘은 보통 디자인시스템에 있는 색상보다 hex 코드로 설정되어있어서 기본을 hex로 입력하게 해뒀습니다 만약 purple-50 등 tailwind config에 설정해둔 색상을 사용하는 경우 useTailwind 속성을 true로 설정해주세요

<br/>

## 📸 스크린샷
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/0e76360b-0605-4a0f-827b-63c8397b3603" />


<br/>