### PR TITLE
fix: Dropdown 사이즈 props 적용하는 요소를 relative 요소로 변경

### DIFF
--- a/src/components/ui/dropdown/Dropdown.tsx
+++ b/src/components/ui/dropdown/Dropdown.tsx
@@ -207,11 +207,17 @@ export default function Dropdown(props: DropdownProps) {
     };
   }, [isOpenState, controlledIsOpen, onClose]);
 
+  const containerSize = useMemo(() => {
+    if (!showTrigger) return '';
+    if (size) return size;
+    return DROPDOWN_SIZE[type];
+  }, [showTrigger, size, type]);
+
   return (
-    <div className='relative select-none'>
+    <div className={`relative select-none ${containerSize}`}>
       {showTrigger && (
         <div
-          className={`flex justify-start items-center ${size || DROPDOWN_SIZE[type]} ${triggerStyles.base} ${
+          className={`flex justify-start items-center w-full h-full ${triggerStyles.base} ${
             disabled ? triggerStyles.disabled : isOpenState ? triggerStyles.open : triggerStyles.closed
           } ${selectedTextStyle || DROPDOWN_TEXT_STYLE[type]} text-nowrap ${disabled ? 'cursor-not-allowed text-label-assistive' : 'cursor-pointer'} select-none`}
           onClick={handleToggle}


### PR DESCRIPTION
## ✅ 작업 사항

- 드롭다운 사이즈 props가 최상위 relative 요소에 적용되도록 수정
- 드롭다운을 사용하는 컨테이너 요소가 드롭다운 사이즈와 일치하지 않을 때 페이지의 중앙에서 메뉴가 펼쳐지는 걸 뒤늦게 발견해서.. 수정했습니다

<br/>

## 📸 스크린샷
- 수정 전
<img width="598" alt="스크린샷 2025-05-19 오후 5 34 25" src="https://github.com/user-attachments/assets/e018eb31-3564-4c31-9597-279958b3e892" />

- 수정 후
<img width="166" alt="스크린샷 2025-05-19 오후 5 33 49" src="https://github.com/user-attachments/assets/a4f134c1-95ee-4ec8-a785-30ff18bb4fd1" />



<br/>
