### PR TITLE
Style/layout: 레이아웃 어색한 부분들 수정

### DIFF
--- a/src/app/(header-layout)/layout.tsx
+++ b/src/app/(header-layout)/layout.tsx
@@ -2,10 +2,12 @@ import Header from '@/components/layouts/Header';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className='flex-1 w-full min-h-screen bg-gray-10'>
-      <div className='flex flex-col justify-start items-start w-full max-w-[1320px] h-full mx-auto'>
+    <div className='flex-1 w-full min-w-fit min-h-screen bg-gray-10'>
+      <div className='flex flex-col justify-start items-start w-full max-w-[1320px] h-full max-[1320px]:px-[20px] mx-auto'>
         <Header />
-        <main className='flex-1 flex flex-col justify-center items-center w-full h-full'>{children}</main>
+        <main className='flex-1 flex flex-col justify-center max-[750px]:items-start items-center w-full h-full'>
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/src/app/(profile-header-layout)/layout.tsx
+++ b/src/app/(profile-header-layout)/layout.tsx
@@ -7,7 +7,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   // TODO: api 연동 후 실제 유저 데이터 받아와 세팅하기
 
   return (
-    <div className='flex-1 w-full min-w-fit min-h-screen bg-gray-10'>
+    <div className='flex-1 w-full min-w-fit min-h-screen bg-gray-10 max-[1310px]:px-[10px]'>
       <div className='flex flex-col justify-start items-start w-full max-w-[1320px] h-full mx-auto'>
         <Header>
           <div className='flex flex-row justify-between items-center gap-[30px]'>

--- a/src/app/(profile-header-layout)/layout.tsx
+++ b/src/app/(profile-header-layout)/layout.tsx
@@ -7,7 +7,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   // TODO: api 연동 후 실제 유저 데이터 받아와 세팅하기
 
   return (
-    <div className='flex-1 w-full min-h-screen bg-gray-10'>
+    <div className='flex-1 w-full min-w-fit min-h-screen bg-gray-10'>
       <div className='flex flex-col justify-start items-start w-full max-w-[1320px] h-full mx-auto'>
         <Header>
           <div className='flex flex-row justify-between items-center gap-[30px]'>

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -8,7 +8,7 @@ interface HeaderProps {
 
 export default function Header({ children }: HeaderProps) {
   return (
-    <header className='flex justify-between items-center w-[1320px] h-[74px] bg-transparent px-[10px] py-[12px]'>
+    <header className='flex justify-between items-center max-w-[1320px] w-full h-[74px] bg-transparent px-[10px] py-[12px]'>
       <Link href='/'>
         <Image
           src='/assets/images/brand/logo.png'

--- a/src/components/quiz/QuizCreateHeader.tsx
+++ b/src/components/quiz/QuizCreateHeader.tsx
@@ -15,7 +15,7 @@ export default function QuizCreateHeader({ onTemporarySave, onRegister }: QuizCr
 
   return (
     <>
-      <div className='flex justify-between items-center w-full h-[50px] mb-[22px]'>
+      <div className='flex justify-between items-center w-[1320px] h-[50px] mb-[22px]'>
         <Link
           href={`/lectures/${lectureId}/quiz`}
           className='w-[136px] px-[5px] text-title3 font-bold flex items-center gap-[15px]'


### PR DESCRIPTION
## ✅ 작업 사항

- 화면 너비가 좁아져도 전체 레이아웃이 콘텐츠 영역(1320px) 이하로 좁아지지 않도록 수정
- 화면 너비가 좁아지면 회원가입 페이지 레이아웃 정렬이 flex flex-col items-center -> items-start로 폼 앞쪽(왼쪽)부터 보이게 수정
- 퀴즈 생성 폼 폼 영역 전체 너비 1320px 고정
- 화면 너비가 1310px 이하일 때 px-[10px] 추가해 내부 요소들이 브라우저에 딱맞게 붙어있지 않도록 수정

<br/>

## 📸 스크린샷
- 전체 레이아웃이 콘텐츠 영역 이하로 좁아지지 않도록 수정 전
<img width="571" alt="image" src="https://github.com/user-attachments/assets/a607d8a1-f546-45cb-9b62-40165f81f249" />


<br/>

- 전체 레이아웃이 콘텐츠 영역 이하로 좁아지지 않도록 수정 후
<img width="336" alt="image" src="https://github.com/user-attachments/assets/2393aeff-5d33-429f-a9b6-acdcc812b3de" />

<br/>
<br/>

- 화면 좁을 때 회원가입 수정 전
<img width="661" alt="image" src="https://github.com/user-attachments/assets/52dbcb9e-8968-4200-a589-27635e78e1d4" />


<br/>

- 화면 좁을 때 회원가입 페이지 수정 후
<img width="679" alt="image" src="https://github.com/user-attachments/assets/926cb251-e2ae-4b68-a59b-23244009beed" />


<br/>
<br/>

- 화면 너비 1310px 이하 px-[10px] 추가 전
<img width="345" alt="image" src="https://github.com/user-attachments/assets/e0a17ff5-400a-43b1-a2b2-87d1f894e43c" />

<br/>

- 화면 너비 1310px 이하 px-[10px] 추가 후
<img width="614" alt="image" src="https://github.com/user-attachments/assets/551b4aa3-49ec-41b7-9397-489bf51b1ac5" />



<br/>


## 🧑‍💻 기타

- 자세한 요구사항이 있는게 아니다보니 제가 보면서 어색한 부분만 우선 설정했는데 혹시 어색한 부분 있으면 알려주세요!