### PR TITLE
진행 퀴즈 관련 수정사항 반영

### DIFF
--- a/src/components/quiz/list/CloseQuizItem.tsx
+++ b/src/components/quiz/list/CloseQuizItem.tsx
@@ -8,9 +8,10 @@ import CloseQuizStats from './CloseQuizStats';
 
 type CloseQuizItemProps = {
   quiz: Quiz;
+  isLastQuiz: boolean;
 };
 
-export default function CloseQuizItem({ quiz }: CloseQuizItemProps) {
+export default function CloseQuizItem({ quiz, isLastQuiz }: CloseQuizItemProps) {
   const { id, title, dueTime, limitTime, submitStudents, totalStudents } = quiz;
   const formattedDueTime = formatDatetimeToYYYYMMDD(dueTime);
 
@@ -19,6 +20,8 @@ export default function CloseQuizItem({ quiz }: CloseQuizItemProps) {
   const handleStatsToggle = () => {
     setIsOpen(!isOpen);
   };
+
+  const showSeparator = !isOpen && !isLastQuiz;
 
   return (
     <div className='flex flex-col w-full gap-[5px]'>
@@ -63,7 +66,7 @@ export default function CloseQuizItem({ quiz }: CloseQuizItemProps) {
           />
         </div>
       </div>
-      {!isOpen && <div className='w-full h-[1px] bg-gray-30' />}
+      {showSeparator && <div className='w-full h-[1px] bg-gray-30' />}
       {isOpen && <CloseQuizStats quizId={id} />}
     </div>
   );

--- a/src/components/quiz/list/CloseQuizList.tsx
+++ b/src/components/quiz/list/CloseQuizList.tsx
@@ -6,6 +6,8 @@ type CloseQuizListProps = {
 };
 
 export default function CloseQuizList({ closedQuizzes }: CloseQuizListProps) {
+  const isLastQuiz = (index: number) => index === closedQuizzes.length - 1;
+
   return (
     <div className='flex flex-col w-full'>
       <h2 className='text-heading2 font-semibold mb-[20px]'>마감 퀴즈</h2>
@@ -14,10 +16,11 @@ export default function CloseQuizList({ closedQuizzes }: CloseQuizListProps) {
           마감된 퀴즈가 없어요.
         </div>
       )}
-      {closedQuizzes.map((quiz) => (
+      {closedQuizzes.map((quiz, index) => (
         <CloseQuizItem
           key={quiz.id}
           quiz={quiz}
+          isLastQuiz={isLastQuiz(index)}
         />
       ))}
     </div>

--- a/src/components/quiz/list/OpenQuizItem.tsx
+++ b/src/components/quiz/list/OpenQuizItem.tsx
@@ -6,16 +6,16 @@ import { Quiz } from '@/types/quiz.types';
 import { formatDatetimeToYYYYMMDD } from '@/utils/date/formatDate';
 import { useModal } from '@/hooks/ui/useModal';
 import Modal from '@/components/ui/Modal';
-import { useToastStore } from '@/stores/toastStore';
 import { usePutQuizState } from '@/hooks/queries/quiz/usePutQuizState';
 import { useLectureId } from '@/hooks/queries/useLectureId';
 
 type OpenQuizItemProps = {
   quiz: Quiz;
   type: 'ongoing' | 'ready';
+  isLastQuiz: boolean;
 };
 
-export default function OpenQuizItem({ quiz, type }: OpenQuizItemProps) {
+export default function OpenQuizItem({ quiz, type, isLastQuiz }: OpenQuizItemProps) {
   const {
     isOpen: isUploadModalOpen,
     openModal: openUploadModal,
@@ -27,8 +27,6 @@ export default function OpenQuizItem({ quiz, type }: OpenQuizItemProps) {
     openModal: openCloseModal,
     closeModal: closeCloseModal,
   } = useModal({ defaultOpen: false });
-
-  const { addToast } = useToastStore();
 
   const { id: quizId, title, limitTime, updatedAt } = quiz;
   const formattedUpdatedAt = formatDatetimeToYYYYMMDD(updatedAt);
@@ -49,76 +47,79 @@ export default function OpenQuizItem({ quiz, type }: OpenQuizItemProps) {
   };
 
   return (
-    <div className='flex justify-between items-center px-[10px] py-[20px]'>
-      <div className='flex items-center gap-[10px]'>
-        <div className='flex justify-center items-center w-[49px] h-[49px] bg-accent-redOrange-5 rounded-[15px]'>
-          <Image
-            src='/assets/icons/category-icon/quiz.png'
-            width={24}
-            height={24}
-            className='object-contain'
-            alt='진행 퀴즈'
-            draggable={false}
-          />
+    <div className='flex flex-col w-full gap-[5px]'>
+      <div className='flex justify-between items-center px-[10px] py-[20px]'>
+        <div className='flex items-center gap-[10px]'>
+          <div className='flex justify-center items-center w-[49px] h-[49px] bg-accent-redOrange-5 rounded-[15px]'>
+            <Image
+              src='/assets/icons/category-icon/quiz.png'
+              width={24}
+              height={24}
+              className='object-contain'
+              alt='진행 퀴즈'
+              draggable={false}
+            />
+          </div>
+          <div className='flex flex-col gap-[5px]'>
+            <h3 className='text-headline1 font-semibold'>{title}</h3>
+            <p className='text-label font-semibold text-gray-50'>{formattedUpdatedAt}</p>
+          </div>
         </div>
-        <div className='flex flex-col gap-[5px]'>
-          <h3 className='text-headline1 font-semibold'>{title}</h3>
-          <p className='text-label font-semibold text-gray-50'>{formattedUpdatedAt}</p>
+        <div className='flex items-center gap-[29px]'>
+          <div className='flex items-center gap-[5px]'>
+            <Image
+              src='/assets/icons/timer.png'
+              width={14}
+              height={16.9}
+              alt='응시 시간'
+              draggable={false}
+            />
+            <span className='text-headline1 font-semibold'>{limitTime}</span>
+          </div>
+          {type === 'ongoing' && (
+            <>
+              <Button
+                type='BUTTON_BASE_TYPE'
+                size='w-fit h-[46px]'
+                font='text-headline2 font-semibold'
+                isPurple
+                title='마감하기'
+                onClick={openCloseModal}
+              />
+              <Modal
+                isOpen={isCloseModalOpen}
+                onCancel={closeCloseModal}
+                onConfirm={handleCloseQuiz}
+                title='퀴즈를 마감하시겠어요?'
+                description='퀴즈를 마감하면 학생들이 더 이상 응시할 수 없어요.'
+                iconSrc='/assets/icons/sidenav/quiz_selected.png'
+              />
+            </>
+          )}
+          {type === 'ready' && (
+            <>
+              <Button
+                type='BUTTON_BASE_TYPE'
+                size='w-fit h-[46px]'
+                font='text-headline2 font-semibold'
+                isPurple
+                isfilled
+                title='게시하기'
+                onClick={openUploadModal}
+              />
+              <Modal
+                isOpen={isUploadModalOpen}
+                onCancel={closeUploadModal}
+                onConfirm={handleUploadQuiz}
+                title='퀴즈를 게시하시겠어요?'
+                description='퀴즈를 게시하면 학생들이 바로 응시할 수 있어요.'
+                iconSrc='/assets/icons/sidenav/quiz_selected.png'
+              />
+            </>
+          )}
         </div>
       </div>
-      <div className='flex items-center gap-[29px]'>
-        <div className='flex items-center gap-[5px]'>
-          <Image
-            src='/assets/icons/timer.png'
-            width={14}
-            height={16.9}
-            alt='응시 시간'
-            draggable={false}
-          />
-          <span className='text-headline1 font-semibold'>{limitTime}</span>
-        </div>
-        {type === 'ongoing' && (
-          <>
-            <Button
-              type='BUTTON_BASE_TYPE'
-              size='w-fit h-[46px]'
-              font='text-headline2 font-semibold'
-              isPurple
-              title='마감하기'
-              onClick={openCloseModal}
-            />
-            <Modal
-              isOpen={isCloseModalOpen}
-              onCancel={closeCloseModal}
-              onConfirm={handleCloseQuiz}
-              title='퀴즈를 마감하시겠어요?'
-              description='퀴즈를 마감하면 학생들이 더 이상 응시할 수 없어요.'
-              iconSrc='/assets/icons/sidenav/quiz_selected.png'
-            />
-          </>
-        )}
-        {type === 'ready' && (
-          <>
-            <Button
-              type='BUTTON_BASE_TYPE'
-              size='w-fit h-[46px]'
-              font='text-headline2 font-semibold'
-              isPurple
-              isfilled
-              title='게시하기'
-              onClick={openUploadModal}
-            />
-            <Modal
-              isOpen={isUploadModalOpen}
-              onCancel={closeUploadModal}
-              onConfirm={handleUploadQuiz}
-              title='퀴즈를 게시하시겠어요?'
-              description='퀴즈를 게시하면 학생들이 바로 응시할 수 있어요.'
-              iconSrc='/assets/icons/sidenav/quiz_selected.png'
-            />
-          </>
-        )}
-      </div>
+      {!isLastQuiz && <div className='w-full h-[1px] bg-gray-30' />}
     </div>
   );
 }

--- a/src/components/quiz/list/OpenQuizItem.tsx
+++ b/src/components/quiz/list/OpenQuizItem.tsx
@@ -9,16 +9,10 @@ import Modal from '@/components/ui/Modal';
 import { useToastStore } from '@/stores/toastStore';
 import { usePutQuizState } from '@/hooks/queries/quiz/usePutQuizState';
 import { useLectureId } from '@/hooks/queries/useLectureId';
-import { useEffect } from 'react';
 
 type OpenQuizItemProps = {
   quiz: Quiz;
   type: 'ongoing' | 'ready';
-};
-
-const SUCCESS_MESSAGE = {
-  ongoing: '퀴즈가 마감되었습니다.',
-  ready: '퀴즈가 게시되었습니다.',
 };
 
 export default function OpenQuizItem({ quiz, type }: OpenQuizItemProps) {
@@ -40,7 +34,7 @@ export default function OpenQuizItem({ quiz, type }: OpenQuizItemProps) {
   const formattedUpdatedAt = formatDatetimeToYYYYMMDD(updatedAt);
 
   const lectureId = useLectureId();
-  const { mutate: mutateQuizState, isSuccess, error } = usePutQuizState({ quizId, lectureId });
+  const { mutate: mutateQuizState } = usePutQuizState({ quizId, lectureId, prevState: type });
 
   // TODO: 로딩상태 추가
 
@@ -53,18 +47,6 @@ export default function OpenQuizItem({ quiz, type }: OpenQuizItemProps) {
     mutateQuizState('ongoing');
     closeUploadModal();
   };
-
-  useEffect(() => {
-    if (isSuccess) {
-      addToast({ message: SUCCESS_MESSAGE[type], type: 'success' });
-    }
-  }, [isSuccess, type]);
-
-  useEffect(() => {
-    if (error) {
-      addToast({ message: error.message, type: 'error' });
-    }
-  }, [error]);
 
   return (
     <div className='flex justify-between items-center px-[10px] py-[20px]'>

--- a/src/components/quiz/list/OpenQuizItem.tsx
+++ b/src/components/quiz/list/OpenQuizItem.tsx
@@ -28,8 +28,8 @@ export default function OpenQuizItem({ quiz, type, isLastQuiz }: OpenQuizItemPro
     closeModal: closeCloseModal,
   } = useModal({ defaultOpen: false });
 
-  const { id: quizId, title, limitTime, updatedAt } = quiz;
-  const formattedUpdatedAt = formatDatetimeToYYYYMMDD(updatedAt);
+  const { id: quizId, title, limitTime, dueTime } = quiz;
+  const formattedDueTime = formatDatetimeToYYYYMMDD(dueTime);
 
   const lectureId = useLectureId();
   const { mutate: mutateQuizState } = usePutQuizState({ quizId, lectureId, prevState: type });
@@ -62,7 +62,7 @@ export default function OpenQuizItem({ quiz, type, isLastQuiz }: OpenQuizItemPro
           </div>
           <div className='flex flex-col gap-[5px]'>
             <h3 className='text-headline1 font-semibold'>{title}</h3>
-            <p className='text-label font-semibold text-gray-50'>{formattedUpdatedAt}</p>
+            <p className='text-label font-semibold text-gray-50'>{formattedDueTime}</p>
           </div>
         </div>
         <div className='flex items-center gap-[29px]'>

--- a/src/components/quiz/list/OpenQuizList.tsx
+++ b/src/components/quiz/list/OpenQuizList.tsx
@@ -1,27 +1,19 @@
 import { QuizList } from '@/types/quiz.types';
 import OpenQuizItem from './OpenQuizItem';
 
-type OngoingQuizListProps = {
-  readyQuizzes: QuizList;
-  ongoingQuizzes: QuizList;
+type OpenQuizListProps = {
+  openQuizzes: QuizList;
 };
 
-export default function OngoingQuizList({ readyQuizzes, ongoingQuizzes }: OngoingQuizListProps) {
+export default function OpenQuizList({ openQuizzes }: OpenQuizListProps) {
   return (
     <div className='flex flex-col gap-[20px] w-full '>
       <h2 className='text-heading2 font-semibold'>진행 퀴즈</h2>
-      {ongoingQuizzes.map((quiz) => (
+      {openQuizzes.map((quiz) => (
         <OpenQuizItem
           key={quiz.id}
           quiz={quiz}
-          type='ongoing'
-        />
-      ))}
-      {readyQuizzes.map((quiz) => (
-        <OpenQuizItem
-          key={quiz.id}
-          quiz={quiz}
-          type='ready'
+          type={quiz.state as 'ongoing' | 'ready'}
         />
       ))}
     </div>

--- a/src/components/quiz/list/OpenQuizList.tsx
+++ b/src/components/quiz/list/OpenQuizList.tsx
@@ -9,6 +9,11 @@ export default function OpenQuizList({ openQuizzes }: OpenQuizListProps) {
   return (
     <div className='flex flex-col gap-[20px] w-full '>
       <h2 className='text-heading2 font-semibold'>진행 퀴즈</h2>
+      {openQuizzes.length === 0 && (
+        <div className='flex justify-center items-center w-full h-[90px] text-heading2 font-semibold text-gray-50'>
+          진행 중인 퀴즈가 없어요.
+        </div>
+      )}
       {openQuizzes.map((quiz) => (
         <OpenQuizItem
           key={quiz.id}

--- a/src/components/quiz/list/OpenQuizList.tsx
+++ b/src/components/quiz/list/OpenQuizList.tsx
@@ -6,6 +6,8 @@ type OpenQuizListProps = {
 };
 
 export default function OpenQuizList({ openQuizzes }: OpenQuizListProps) {
+  const isLastQuiz = (index: number) => index === openQuizzes.length - 1;
+
   return (
     <div className='flex flex-col gap-[20px] w-full '>
       <h2 className='text-heading2 font-semibold'>진행 퀴즈</h2>
@@ -14,13 +16,16 @@ export default function OpenQuizList({ openQuizzes }: OpenQuizListProps) {
           진행 중인 퀴즈가 없어요.
         </div>
       )}
-      {openQuizzes.map((quiz) => (
-        <OpenQuizItem
-          key={quiz.id}
-          quiz={quiz}
-          type={quiz.state as 'ongoing' | 'ready'}
-        />
-      ))}
+      <div className='flex flex-col gap-[5px]'>
+        {openQuizzes.map((quiz, index) => (
+          <OpenQuizItem
+            key={quiz.id}
+            quiz={quiz}
+            type={quiz.state as 'ongoing' | 'ready'}
+            isLastQuiz={isLastQuiz(index)}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/quiz/list/QuizListContainer.tsx
+++ b/src/components/quiz/list/QuizListContainer.tsx
@@ -27,12 +27,11 @@ export default function QuizListContainer() {
   const lectureId = useLectureId();
   const { data: quizList } = useGetQuizList(lectureId);
 
-  const { readyQuizzes, ongoingQuizzes, closedQuizzes } = useMemo(() => {
-    const ready = quizList?.filter((quiz) => quiz.state === 'ready') ?? [];
-    const ongoing = quizList?.filter((quiz) => quiz.state === 'ongoing') ?? [];
+  const { openQuizzes, closedQuizzes } = useMemo(() => {
+    const open = quizList?.filter((quiz) => quiz.state === 'ready' || quiz.state === 'ongoing') ?? [];
     const closed = quizList?.filter((quiz) => quiz.state === 'closed') ?? [];
 
-    return { readyQuizzes: ready, ongoingQuizzes: ongoing, closedQuizzes: closed };
+    return { openQuizzes: open, closedQuizzes: closed };
   }, [quizList]);
 
   return (
@@ -57,10 +56,7 @@ export default function QuizListContainer() {
       {selectedQuizCategory === '전체' && (
         <>
           <div className='flex flex-col justify-start items-start gap-[45px]'>
-            <OpenQuizList
-              readyQuizzes={readyQuizzes}
-              ongoingQuizzes={ongoingQuizzes}
-            />
+            <OpenQuizList openQuizzes={openQuizzes} />
             <CloseQuizList closedQuizzes={closedQuizzes} />
           </div>
         </>

--- a/src/hooks/queries/quiz/usePutQuizState.ts
+++ b/src/hooks/queries/quiz/usePutQuizState.ts
@@ -1,6 +1,14 @@
+'use client';
+
 import { QuizState } from '@/types/quiz.types';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { QUERY_KEYS } from '../queryKeys';
+import { useToastStore } from '@/stores/toastStore';
+
+const SUCCESS_MESSAGE: Record<Exclude<QuizState, 'closed'>, string> = {
+  ongoing: '퀴즈가 마감되었습니다.',
+  ready: '퀴즈가 게시되었습니다.',
+};
 
 const putQuizState = async (quizId: string, state: Exclude<QuizState, 'ready'>) => {
   const response = await fetch(`${process.env.NEXT_PUBLIC_MOCK_BASE_URL}/api/teachers/quizzes/${quizId}/${state}`, {
@@ -17,13 +25,26 @@ const putQuizState = async (quizId: string, state: Exclude<QuizState, 'ready'>) 
   return response.json();
 };
 
-export const usePutQuizState = ({ quizId, lectureId }: { quizId: string; lectureId: string }) => {
+export const usePutQuizState = ({
+  quizId,
+  lectureId,
+  prevState,
+}: {
+  quizId: string;
+  lectureId: string;
+  prevState: Exclude<QuizState, 'closed'>;
+}) => {
   const queryClient = useQueryClient();
+  const { addToast } = useToastStore();
 
   return useMutation({
     mutationFn: (state: Exclude<QuizState, 'ready'>) => putQuizState(quizId, state),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.quizList(lectureId) });
+      addToast({ message: SUCCESS_MESSAGE[prevState], type: 'success' });
+    },
+    onError: (error) => {
+      addToast({ message: error.message, type: 'error' });
     },
   });
 };


### PR DESCRIPTION
## ✅ 작업 사항

- 진행퀴즈가 여러개인 경우 구분선 추가
- 진행퀴즈 타이틀 아래에 보이는 날짜를 마감 시간으로 변경
- 진행퀴즈 mutation 성공/실패시 토스트메세지 처리를 useMutation 내부로 이동
- 진행퀴즈에서 ready, ongoing 상태 구분하지 않고 받아온 그대로 정렬하도록 수정
- 마감퀴즈 마지막은 구분선이 보이지 않도록 수정

<br/>

## 📸 스크린샷
<img width="1384" alt="image" src="https://github.com/user-attachments/assets/7c8e214f-6c42-4c3f-a972-53d88544dfb1" />

<br/>