### PR TITLE
Fix/api response type: API 응답 타입에 맞게 서버액션 반환타입 변경, useApi에 공통로직 추가

### DIFF
--- a/src/app/(profile-header-layout)/(navigation-layout)/lectures/[lectureId]/homework/detail/page.tsx
+++ b/src/app/(profile-header-layout)/(navigation-layout)/lectures/[lectureId]/homework/detail/page.tsx
@@ -21,16 +21,18 @@ export default function HomeworkDetail() {
   // GET : 과제 목록 (진행중, 마감) 에서 받아온 데이터로 변경하기
   const detailData = MOCK_HOMEWORK.data[filter].find((item) => item.id === Number(id));
 
-  const deleteMutation = useApiMutation<unknown, any>(
-    'DELETE',
-    `/teachers/assignments/${id}`,
-    () => addToast({ message: '과제가 삭제되었어요', type: 'success', duration: 2500 }),
-    [QUERY_KEYS.homeworkList(lectureNum)],
-    (err) => {
-      addToast({ message: '과제가 삭제되지 않았어요. 다시 시도해주세요.', type: 'error', duration: 2500 });
-      console.log(err);
+  const deleteMutation = useApiMutation<unknown, void>({
+    method: 'DELETE',
+    endpoint: `/teachers/assignments/${id}`,
+    fetchOptions: {
+      authorization: true,
     },
-  );
+    onSuccess: () => addToast({ message: '과제가 삭제되었어요', type: 'success', duration: 2500 }),
+    invalidateKey: QUERY_KEYS.homeworkList(lectureNum),
+    onError: (error: Error) => {
+      addToast({ message: '과제가 삭제되지 않았어요. 다시 시도해주세요.', type: 'error', duration: 2500 });
+    },
+  });
 
   const handleDelete = () => {
     deleteMutation.mutate(undefined);

--- a/src/components/ui/create/Create.tsx
+++ b/src/components/ui/create/Create.tsx
@@ -67,29 +67,45 @@ export default function Create({ type, params }: CreateProps) {
     ? [QUERY_KEYS.homeworkDetail(homeworkId), QUERY_KEYS.homeworkList(lectureNum)]
     : [QUERY_KEYS.homeworkList(lectureNum)];
 
-  const mutation = useApiMutation<unknown, any>(
+  const mutation = useApiMutation<unknown, FormData>({
     method,
     endpoint,
-    () => {
+    fetchOptions: {
+      authorization: true,
+      contentType: 'multipart/form-data',
+    },
+    onSuccess: () => {
       addToast({ message: `${title}가 ${homeworkId ? '수정' : '생성'}되었어요.`, type: 'success', duration: 2500 });
     },
-    invalidateKeys,
-    (err) => {
+    invalidateKey: invalidateKeys,
+    onError: (error: Error) => {
       addToast({
         message: `${title}가 ${homeworkId ? '수정' : '생성'}되지 않았어요. 다시 시도해주세요.`,
         type: 'error',
         duration: 2500,
       });
     },
-  );
+  });
 
   const onSubmit = (data: WriteBoxFormValues) => {
-    const payload = {
-      ...data,
-      files: Array.isArray(data?.files) ? data.files.join(',') : typeof data?.files === 'string' ? data.files : '',
-    };
-    alert(JSON.stringify(payload));
-    mutation.mutate(payload);
+    const formData = new FormData();
+    formData.append('title', data.title);
+    formData.append('description', data.description);
+    formData.append('isDraft', String(data.isDraft));
+    formData.append('openTime', data.openTime);
+    formData.append('dueTime', data.dueTime);
+
+    if (data.files) {
+      if (Array.isArray(data.files)) {
+        data.files.forEach((file) => {
+          formData.append('files', file);
+        });
+      } else {
+        formData.append('files', data.files);
+      }
+    }
+
+    mutation.mutate(formData);
   };
 
   return (

--- a/src/features/profile/profile.action.ts
+++ b/src/features/profile/profile.action.ts
@@ -1,51 +1,7 @@
 'use server';
 
-import { profileSchema } from '@/features/profile/profile.schema';
 import { ProfileResponse, UserProfileData } from '@/features/profile/profile.types';
 import { fetcher } from '@/utils/api/api';
-import { ActionResponse } from '@/types/response.types';
-
-export const getProfileAction = async (): Promise<ActionResponse<UserProfileData>> => {
-  const response = await fetcher<ProfileResponse>({
-    method: 'GET',
-    endpoint: '/teachers/profile',
-    authorization: true,
-    errorMessage: '프로필 정보를 가져오는데 실패했어요.',
-  });
-
-  if (response.status === 'error') {
-    if (process.env.NODE_ENV === 'development') console.error('----- api 에러 ------');
-    if (process.env.NODE_ENV === 'development') console.error(response);
-
-    return {
-      status: 'error',
-      code: response.code,
-      message: response.message,
-    };
-  }
-
-  const parsedData = profileSchema.safeParse(response.data);
-  if (!parsedData.success) {
-    if (process.env.NODE_ENV === 'development') console.error('----- 프로필정보 파싱 에러 ------');
-    if (process.env.NODE_ENV === 'development') console.error('json: ', response);
-    if (process.env.NODE_ENV === 'development') console.error(parsedData.error);
-    return {
-      status: 'error',
-      code: 500,
-      message: '올바르지 않은 프로필 정보입니다.',
-    };
-  }
-
-  return {
-    status: 'success',
-    code: 200,
-    data: {
-      name: parsedData.data.name,
-      image: parsedData.data.image,
-      bio: parsedData.data.introduction,
-    },
-  };
-};
 
 export const getProfileServer = async (): Promise<UserProfileData> => {
   const response = await fetcher<ProfileResponse>({
@@ -55,8 +11,8 @@ export const getProfileServer = async (): Promise<UserProfileData> => {
     errorMessage: '프로필 정보를 가져오는데 실패했어요.',
   });
 
-  if (response.status === 'error') {
-    return Promise.reject(response.message);
+  if (response.status === 'fail') {
+    return Promise.reject(response.data);
   }
 
   return { name: response.data.name, image: response.data.image, bio: response.data.introduction };

--- a/src/features/profile/useProfileQuery.ts
+++ b/src/features/profile/useProfileQuery.ts
@@ -1,26 +1,30 @@
 'use client';
 
 import { QUERY_KEYS } from '@/hooks/queries/queryKeys';
-import { useQuery } from '@tanstack/react-query';
-import { getProfileAction } from '@/features/profile/profile.action';
-import { UserProfileData } from './profile.types';
+import { ProfileResponse, UserProfileData } from '@/features/profile/profile.types';
+import { useApiQuery } from '@/hooks/useApi';
+import { profileSchema } from '@/features/profile/profile.schema';
 
-export const getProfile = async () => {
-  const response = await getProfileAction();
-
-  if (response.status === 'error') {
-    throw new Error(response.message);
-  }
-
-  return response.data;
-};
-
-export const useGetProfileData = (options?: { initialData?: UserProfileData }) => {
-  return useQuery<UserProfileData>({
-    queryKey: QUERY_KEYS.profile(),
-    queryFn: getProfile,
-    staleTime: 1000 * 60 * 60, // 1시간
-    gcTime: 1000 * 60 * 60 * 3, // 3시간
-    ...options,
+export const useGetProfileData = () => {
+  return useApiQuery<ProfileResponse, UserProfileData>({
+    key: QUERY_KEYS.profile(),
+    fetchOptions: {
+      endpoint: '/teachers/profile',
+      authorization: true,
+      errorMessage: '프로필 정보를 가져오는데 실패했어요.',
+    },
+    schema: profileSchema,
+    transform: (data) => ({
+      name: data.name,
+      image: data.image,
+      bio: data.introduction,
+    }),
+    queryOptions: {
+      staleTime: 1000 * 60 * 60 * 1,
+      gcTime: 1000 * 60 * 60 * 3,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+    },
   });
 };

--- a/src/features/profile/useProfileQuery.ts
+++ b/src/features/profile/useProfileQuery.ts
@@ -7,7 +7,7 @@ import { profileSchema } from '@/features/profile/profile.schema';
 
 export const useGetProfileData = () => {
   return useApiQuery<ProfileResponse, UserProfileData>({
-    key: QUERY_KEYS.profile(),
+    queryKey: QUERY_KEYS.profile(),
     fetchOptions: {
       endpoint: '/teachers/profile',
       authorization: true,

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -22,7 +22,7 @@ export function validateResponse<T>(schema: z.ZodSchema<T>, data: unknown): T {
 
 type UseApiQueryOptions<T, R = T> = {
   /** Tanstack Query의 쿼리 키 */
-  key: readonly unknown[];
+  queryKey: readonly unknown[];
   /** API 요청을 위한 옵션 (method 제외) */
   fetchOptions: Omit<FetchOptions, 'method'>;
   /** Tanstack Query의 추가 옵션 (queryKey와 queryFn 제외) */
@@ -63,14 +63,14 @@ type UseApiQueryOptions<T, R = T> = {
  */
 
 export function useApiQuery<T, R = T>({
-  key,
+  queryKey,
   fetchOptions,
   queryOptions,
   schema,
   transform,
 }: UseApiQueryOptions<T, R>) {
   return useQuery<R, Error>({
-    queryKey: key,
+    queryKey,
     queryFn: async (): Promise<R> => {
       const response = await fetcher<T>({ method: 'GET', ...fetchOptions });
 

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,48 +1,258 @@
-import { fetcher, Method } from '@/utils/api/api';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+'use client';
 
-export function useApiQuery<T>(
-  key: readonly unknown[],
-  endpoint: string,
-  enabled = true,
-  options?: {
-    staleTime?: number;
-    gcTime?: number;
-  },
-) {
-  return useQuery<T, Error>({
+import { fetcher, FetchOptions, Method } from '@/utils/api/api';
+import { MutationOptions, UseQueryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { z } from 'zod';
+
+export function validateResponse<T>(schema: z.ZodSchema<T>, data: unknown): T {
+  const result = schema.safeParse(data);
+
+  if (!result.success) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('----- API 응답 검증 실패 ------');
+      console.error('응답 데이터: ', data);
+      console.error('에러 메시지: ', result.error.message);
+    }
+
+    throw new Error(`잘못된 형식의 응답입니다. ${result.error.message}`);
+  }
+
+  return result.data;
+}
+
+type UseApiQueryOptions<T, R = T> = {
+  /** Tanstack Query의 쿼리 키 */
+  key: readonly unknown[];
+  /** API 요청을 위한 옵션 (method 제외) */
+  fetchOptions: Omit<FetchOptions, 'method'>;
+  /** Tanstack Query의 추가 옵션 (queryKey와 queryFn 제외) */
+  queryOptions?: Omit<UseQueryOptions<R, Error>, 'queryKey' | 'queryFn'>;
+  /** API 응답 데이터 검증을 위한 Zod 스키마 */
+  schema?: z.ZodSchema<T>;
+  /** API 응답 데이터를 변환하는 함수 */
+  transform?: (data: T) => R;
+};
+
+/**
+ * API 쿼리 훅 - GET 요청을 위한 Tanstack Query 래퍼
+ * @template T API 응답 데이터의 타입
+ * @template R 변환된 응답 데이터의 타입 (기본값은 T)
+ *
+ * @param {UseApiQueryOptions<T, R>} options - API 쿼리 옵션
+ * @param {readonly unknown[]} options.key - Tanstack Query의 쿼리 키
+ * @param {Omit<FetchOptions, 'method'>} options.fetchOptions - API 요청을 위한 옵션 (method 제외)
+ * @param {Omit<UseQueryOptions<R, Error>, 'queryKey' | 'queryFn'>} [options.queryOptions] - Tanstack Query의 추가 옵션
+ * @param {z.ZodSchema<T>} [options.schema] - API 응답 데이터 검증을 위한 Zod 스키마
+ * @param {(data: T) => R} [options.transform] - API 응답 데이터를 변환하는 함수
+ * @returns Tanstack Query의 쿼리 결과
+ * @example
+ * ```ts
+ * const { data, isLoading } = useApiQuery({
+ *   key: QUERY_KEYS.profile(),
+ *   fetchOptions: {
+ *     endpoint: '/teachers/profile',
+ *     authorization: true
+ *   },
+ *   schema: profileSchema,
+ *   transform: (data) => ({
+ *     name: data.name,
+ *     image: data.image
+ *   })
+ * });
+ * ```
+ */
+
+export function useApiQuery<T, R = T>({
+  key,
+  fetchOptions,
+  queryOptions,
+  schema,
+  transform,
+}: UseApiQueryOptions<T, R>) {
+  return useQuery<R, Error>({
     queryKey: key,
-    queryFn: async () => {
-      const response = await fetcher<T>({ method: 'GET', endpoint });
-      if (response.status === 'error') {
-        throw new Error(response.message);
+    queryFn: async (): Promise<R> => {
+      const response = await fetcher<T>({ method: 'GET', ...fetchOptions });
+
+      if (response.status === 'fail') {
+        throw new Error(response.data);
       }
-      return response.data;
+
+      if (schema) {
+        return validateResponse(schema, response.data) as unknown as R;
+      }
+
+      if (transform) {
+        return transform(response.data) as R;
+      }
+
+      return response.data as unknown as R;
     },
-    enabled,
-    staleTime: options?.staleTime,
-    gcTime: options?.gcTime,
+    ...queryOptions,
   });
 }
 
-export function useApiMutation<T, V>(
-  method: Exclude<Method, 'GET'>,
-  endpoint: string,
-  onSuccess?: () => void,
-  invalidateKey?: readonly unknown[] | readonly unknown[][],
-  onError?: (err: Error) => void,
-) {
+/**
+ * API Mutation 훅의 옵션 타입
+ * @template T API 응답 데이터의 타입
+ * @template V 요청 데이터(body)의 타입
+ * @template R 변환된 응답 데이터의 타입 (기본값은 T)
+ */
+type UseApiMutationOptions<T, V, R = T> = {
+  /** HTTP 메서드 (GET 제외) */
+  method: Exclude<Method, 'GET'>;
+  /** API 엔드포인트 */
+  endpoint: string;
+  /** API 요청을 위한 옵션 (method와 endpoint 제외) */
+  fetchOptions: Omit<FetchOptions, 'method' | 'endpoint'>;
+  /** 요청 데이터 검증을 위한 Zod 스키마 */
+  requestSchema?: z.ZodSchema<V>;
+  /** 응답 데이터 검증을 위한 Zod 스키마 */
+  responseSchema?: z.ZodSchema<T>;
+  /**
+   * 요청 데이터를 변환하는 함수
+   * @param data - 변환할 요청 데이터
+   * @returns 변환된 요청 데이터
+   */
+  requestTransform?: (data: V) => unknown;
+  /**
+   * 응답 데이터를 변환하는 함수
+   * @param data - 변환할 응답 데이터
+   * @returns 변환된 응답 데이터
+   */
+  responseTransform?: (data: T) => R;
+  /**
+   * Mutation 성공 시 호출되는 콜백 함수
+   * @param data - 변환된 응답 데이터
+   */
+  onSuccess?: (data?: R) => void;
+  /**
+   * Mutation 성공 시 무효화할 쿼리 키
+   * 단일 키 또는 키 배열의 배열을 전달할 수 있습니다
+   */
+  invalidateKey?: readonly unknown[] | readonly unknown[][];
+  /**
+   * Mutation 실패 시 호출되는 콜백 함수
+   * @param err - 발생한 에러
+   */
+  onError?: (err: Error) => void;
+  /** Tanstack Query의 mutation 옵션 (mutationFn, onSuccess, onError 제외) */
+  mutationOptions?: Omit<MutationOptions<R, Error, V>, 'mutationFn' | 'onSuccess' | 'onError'>;
+};
+
+/**
+ * API Mutation 훅 - POST, PUT, DELETE 등의 mutation 요청을 위한 Tanstack Query 래퍼
+ *
+ * @template T API 응답 데이터의 타입
+ * @template V 요청 데이터(body)의 타입
+ * @template R 변환된 응답 데이터의 타입 (기본값은 T)
+ *
+ * @param {UseApiMutationOptions<T, V, R>} options - API Mutation 옵션
+ * @param {Exclude<Method, 'GET'>} options.method - HTTP 메서드
+ * @param {string} options.endpoint - API 엔드포인트
+ * @param {Omit<FetchOptions, 'method' | 'endpoint'>} options.fetchOptions - API 요청 옵션
+ * @param {z.ZodSchema<V>} [options.requestSchema] - 요청 데이터 검증을 위한 Zod 스키마
+ * @param {z.ZodSchema<T>} [options.responseSchema] - 응답 데이터 검증을 위한 Zod 스키마
+ * @param {(data: V) => unknown} [options.requestTransform] - 요청 데이터 변환 함수
+ * @param {(data: T) => R} [options.responseTransform] - 응답 데이터 변환 함수
+ * @param {(data?: R) => void} [options.onSuccess] - 성공 시 콜백 함수
+ * @param {readonly unknown[] | readonly unknown[][]} [options.invalidateKey] - 무효화할 쿼리 키
+ * @param {(err: Error) => void} [options.onError] - 실패 시 콜백 함수
+ * @param {Omit<MutationOptions<R, Error, V>, 'mutationFn' | 'onSuccess' | 'onError'>} [options.mutationOptions] - Tanstack Query mutation 옵션
+ *
+ * @returns Tanstack Query의 mutation 결과
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useApiMutation<ProfileResponse, UpdateProfileRequest, TransformedProfile>({
+ *   method: 'PUT',
+ *   endpoint: '/teachers/profile',
+ *   requestSchema: updateProfileRequestSchema,
+ *   responseSchema: profileResponseSchema,
+ *   requestTransform: (data) => ({
+ *     ...data,
+ *     bio: data.bio.trim(),
+ *   }),
+ *   responseTransform: (data) => ({
+ *     fullName: `${data.firstName} ${data.lastName}`,
+ *     bio: data.bio || '소개가 없습니다',
+ *     imageUrl: data.imageUrl || '/default-avatar.png',
+ *     lastUpdated: new Date(data.updatedAt).toLocaleDateString('ko-KR'),
+ *   }),
+ *   fetchOptions: {
+ *     authorization: true,
+ *   },
+ *   onSuccess: (data) => {
+ *     console.log(data.fullName);
+ *   },
+ * });
+ * ```
+ */
+export function useApiMutation<T, V, R = T>({
+  method,
+  endpoint,
+  fetchOptions,
+  requestSchema,
+  responseSchema,
+  requestTransform,
+  responseTransform,
+  onSuccess,
+  invalidateKey,
+  onError,
+  mutationOptions,
+}: UseApiMutationOptions<T, V, R>) {
   const queryClient = useQueryClient();
 
-  return useMutation<T, Error, V>({
-    mutationFn: async (body: V) => {
-      const response = await fetcher<T>({ method, endpoint, body });
-      if (response.status === 'error') {
-        throw new Error(response.message);
+  const handleSuccess = (data?: R) => {
+    if (invalidateKey) {
+      if (Array.isArray(invalidateKey[0])) {
+        (invalidateKey as readonly unknown[][]).forEach((key) => {
+          queryClient.invalidateQueries({ queryKey: key });
+        });
+      } else {
+        queryClient.invalidateQueries({ queryKey: invalidateKey });
       }
-      return response.data;
+    }
+    onSuccess?.(data);
+  };
+
+  return useMutation<R, Error, V>({
+    mutationFn: async (body: V) => {
+      // 요청 데이터 검증
+      if (requestSchema) {
+        const result = requestSchema.safeParse(body);
+        if (!result.success) {
+          if (process.env.NODE_ENV === 'development') {
+            console.error('----- API 요청 데이터 검증 실패 ------');
+            console.error('요청 데이터: ', body);
+            console.error('에러 메시지: ', result.error.message);
+          }
+          throw new Error(`잘못된 형식의 요청 데이터입니다. ${result.error.message}`);
+        }
+      }
+
+      // 요청 데이터 변환
+      const transformedBody = requestTransform ? requestTransform(body) : body;
+
+      const response = await fetcher<T>({
+        method,
+        endpoint,
+        body: transformedBody,
+        ...fetchOptions,
+      });
+
+      if (response.status === 'fail') {
+        throw new Error(response.data);
+      }
+
+      // 응답 데이터 검증
+      const validatedData = responseSchema ? validateResponse(responseSchema, response.data) : response.data;
+
+      // 응답 데이터 변환
+      return responseTransform ? (responseTransform(validatedData) as R) : (validatedData as unknown as R);
     },
-    onSuccess,
+    onSuccess: handleSuccess,
     onError,
+    ...mutationOptions,
   });
 }

--- a/src/types/response.types.ts
+++ b/src/types/response.types.ts
@@ -1,5 +1,3 @@
-export type Response<T> = { status: 'success'; code: number; data: T } | { status: 'error'; code: number };
-
 export type ActionResponse<T> =
   | {
       status: 'success';
@@ -7,7 +5,7 @@ export type ActionResponse<T> =
       data: T;
     }
   | {
-      status: 'error';
+      status: 'fail';
       code: number;
-      message: string;
+      data: string;
     };

--- a/src/utils/api/api.ts
+++ b/src/utils/api/api.ts
@@ -17,7 +17,7 @@ export type ContentType = 'application/json' | 'multipart/form-data';
  * @property {string} [errorMessage] - API 요청 실패 시 표시할 에러 메시지
  * @returns {Promise<T>} API 응답 데이터 (response.json()으로 변환된 값)
  */
-type FetchOptions = {
+export type FetchOptions = {
   method: Method;
   endpoint: string;
   body?: any;
@@ -40,7 +40,7 @@ export async function fetcher<T>({
     const accessTokenCookie = cookies().get('accessToken');
 
     if (!accessTokenCookie) {
-      return { status: 'error', code: 401, message: ERROR_MESSAGES.ACCESS_TOKEN_NOT_FOUND };
+      return { status: 'fail', code: 401, data: ERROR_MESSAGES.ACCESS_TOKEN_NOT_FOUND };
     }
 
     accessToken = accessTokenCookie?.value;
@@ -73,14 +73,10 @@ export async function fetcher<T>({
   if (!res.ok) {
     const err = await res.json().catch(() => {});
     if (process.env.NODE_ENV === 'development') console.error('----- API 요청 실패 ------');
-    if (process.env.NODE_ENV === 'development') console.error(res.status);
+    if (process.env.NODE_ENV === 'development') console.error('상태코드: ', res.status);
     if (process.env.NODE_ENV === 'development') console.error(err);
 
-    if (res.status === 401) {
-      return { status: 'error', code: 401, message: ERROR_MESSAGES.UNAUTHORIZED };
-    }
-
-    return { status: 'error', code: res.status, message: errorMessage || err.message || 'API 요청 실패' };
+    return { status: 'fail', code: res.status, data: errorMessage || err.message || 'API 요청 실패' };
   }
 
   const data = await res.json();


### PR DESCRIPTION
## ✅ 작업 사항

- api 응답 타입에 맞게 status: 'success' | 'error' => status: 'success' | 'fail'로 변경
- useApi에 파라미터, 공통적으로 사용할 수 있는 로직 추가 (optional)
- 파라미터를 객체로 변경 => 전달해야하는 값들이 복잡한데 순서대로 맞추려면 오히려 힘들 것 같아서 객체로 전달할 수 있도록 변경했습니다! 관련해서 JSDocs 주석으로 설명 추가했습니다
- 기존 useApiMutation 사용한 부분 인터페이스 변경에 맞게 수정

<br/>

## 🧑‍💻 기타

- 지영님 error -> fail로 바꾸는게 좋으시면 이 PR 바로 develop으로 합쳐주세요!
- error 유지하는게 좋다고 생각되시면 편하게 의견 알려주세용 그런데 useApi 내부 로직 추가한 부분은 필요하다고 생각이 됩니다! (데이터 검증, 변환, 쿼리키 관리 등은 계속 활용해야할텐데 훅 내부에서 관리하면 훨씬 코드 양이나 시간적인 부분에서도 절약이 될 것 같아요)
- useApiMutation 사용하셨던 부분 빌드에러 발생하지 않도록 수정했습니다! 점검 부탁드려용!!